### PR TITLE
250110 python libs for flask : [CHORE] numpy와 scikit learn의 version 변경

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask==3.0.0
-elasticsearch==8.15.3
+elasticsearch==8.17.0
 sentence-transformers==3.3.1
 torch==2.5.1
-numpy==1.23.5
-scikit-learn==1.2.2
+numpy==1.26.0
+scikit-learn==1.4.0


### PR DESCRIPTION
**설명 (필수)**

1. #2 의 연장선

2. python3.12을 위해 numpy 1.26.0, scikit learn 1.4.0로 version 변경

---

**review 참고 사항 (선택)**

1. 가상환경 venv에서 libs 설치